### PR TITLE
only labels script

### DIFF
--- a/make_named_map.js
+++ b/make_named_map.js
@@ -1,0 +1,13 @@
+var util = require('./util.js');
+
+function make(name) {
+  var json = util.node()[name];
+  return JSON.stringify({
+    "name": name ,
+    "auth":"open",
+    "version": "0.0.1",
+    'layergroup': json 
+  })
+}
+
+console.log(make(process.argv[2]));

--- a/tilemill/global_variables_only_labels.mss
+++ b/tilemill/global_variables_only_labels.mss
@@ -1,0 +1,116 @@
+@polygoncolor: #ffd479;
+@cachebuster: #0000c7;
+@water: #cdd2d4;
+
+
+Map {
+  buffer-size: 256;
+}
+
+@landmass_fill: lighten(#e3e3dc, 8%);
+@landmass_line: darken(#bfc7c8, 10%);
+
+@greenareas_fill_low: lighten(#d4dad6,8%);
+@greenareas_fill_medium: lighten(#d4dad6,5%);
+@greenareas_fill_high: lighten(#d4dad6,6%);
+
+@buildings: lighten(#e3e3dc, 5%);
+@buildings_outline_16: #ddd;
+@buildings_outline: #ddd;
+
+@aeroways: #e8e8e8;
+
+@ne10roads_line_color: white;
+@ne10roads_line_outline: darken(#b4b2a3, 2%);
+@ne10roads_7_minor_color: darken(@ne10roads_line_color,12%);
+
+@ne_rivers_stroke: lighten(#346fa1,30%);
+@ne_rivers_casing: darken(#f5f5f3,1%);
+
+@urbanareas: darken(#f5f5f3, 4%);
+@urbanareas_highzoom: darken(#f5f5f3, 3%);
+
+
+@admin0_4: lighten(#c79297, 20%); 
+@admin0_5: lighten(#c99297,10%);
+@admin0_6: mix(lighten(#c99297, 20%), lighten(#e3e3dc, 8%), 20);
+@admin0_7: lighten(#c99297,20%);
+
+@admin1_lowzoom: lighten(#6d6e71, 40%);
+@admin1_highzoom: lighten(#c79297, 15%);
+
+@admin1_labels: #ccc;
+@admin1_labels_halo: white;
+
+//osm roads
+@rail_line: #dddddd;
+@rail_dashline: #fafafa;
+
+@osm_roads_z9_highway_casing: #ccc;
+@osm_roads_z9_highway_stroke: white;
+@osm_roads_z9_major_stroke: #d3d3d3;
+
+@osm_roads_z10_highway_casing: #ccc;
+@osm_roads_z10_highway_stroke: white;
+@osm_roads_z10_major_stroke: #ccc;
+@osm_roads_z10_minor_stroke: #ddd;
+
+@osm_roads_z11_highway_casing: #ccc;
+@osm_roads_z11_highway_stroke: white;
+@osm_roads_z11_major_stroke: #d4d4d4;
+@osm_roads_z11_minor_stroke: #ddd;
+
+@osm_roads_z12_highway_casing: #c4c4c4;
+@osm_roads_z12_highway_stroke: white;
+@osm_roads_z12_major_casing: #d9d9d9;
+@osm_roads_z12_major_stroke: #fefefe;
+@osm_roads_z12_minor_stroke: #ddd;
+
+@osm_roads_z13_highway_casing: #c0c0c0;
+@osm_roads_z13_highway_stroke: white;
+@osm_roads_z13_major_casing: #ccc;
+@osm_roads_z13_major_stroke: #fcfcfc;
+@osm_roads_z13_minor_stroke: #ddd;
+
+@osm_roads_z14plus_highway_casing: #bbb;
+@osm_roads_z14plus_highway_stroke: white;
+@osm_roads_z14plus_major_casing: #c4c4c3;
+@osm_roads_z14plus_major_stroke: white;
+@osm_roads_z14plus_minor_casing: #ddd;
+@osm_roads_z14plus_minor_stroke: #f9f9f9;
+
+@osm_roads_path_stroke: #eee;
+@osm_tunnel_stroke: #eee;
+
+// labels
+@label_foreground_fill: #8494a1;
+@label_foreground_halo_fill: rgba(236,236,234,0.3);
+@label_background_fill: #b6b6b6;
+@label_background_halo_fill: rgba(255,255,255,0.3);
+@labels_lowzoom_shield_fill: lighten(@label_foreground_fill, 7%); 
+@labels_lowzoom_shield_halo_fill: lighten(@label_foreground_halo_fill,10%);
+@labels_highzoom_text_fill: lighten(@label_foreground_fill,15%);
+@labels_highzoom_halo_fill: lighten(@label_foreground_halo_fill,10%);
+
+@labels_highzoom_class1_text_fill: lighten(@label_foreground_fill,5%);
+@labels_highzoom_class2_text_fill: darken(@label_foreground_fill,5%);
+
+@labels_marine_fill: white;
+@labels_marine_halo_fill: lighten(@label_foreground_fill,10%);
+
+@osm_roads_labels_fill: #bbb;
+@osm_roads_labels_halo: white;
+
+// assets
+@city_shield_file: url("https://dl.dropboxusercontent.com/u/2682489/city_shield_light.svg");
+@city_shield_file_lowzoom: url("https://dl.dropboxusercontent.com/u/2682489/city_shield_light.svg");
+@capital_shield_file: url("https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/capital_shield_light.png");
+@capital_shield_file_lowzoom: url("https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/capital_shield_light.png");
+
+@label_park_halo_fill: lighten(#e3e3dc, 8%);
+@label_park_fill: darken(#d4ded6, 30%);
+
+@label_water_halo_fill: lighten(#e3e3dc, 8%);
+@label_water_fill: lighten(#6b8a95, 5%);
+
+@park_texture_opacity: 0.0;

--- a/util.js
+++ b/util.js
@@ -19,6 +19,7 @@ var node = function() {
   var mapconfig_dark = {'layers':[]};
   var mapconfig_light_nolabels = {'layers':[]};
   var mapconfig_dark_nolabels = {'layers':[]};
+  var mapconfig_light_only_labels = {'layers':[]};
 
   // change the host for the images
   function replaceImages(cartocss) {
@@ -84,11 +85,25 @@ var node = function() {
     mapconfig_dark_nolabels.layers.push(new_layer);
   });
 
+  PROJECT.layers.forEach(function(l) {
+    new_layer = {'type':'cartodb','options':{'cartocss_version':'2.1.1'}};
+    new_layer.name = l.name;
+    new_layer.options.sql = l.options.sql;
+    if (l.name == "global_variables") {
+      new_layer.options.cartocss = replaceImages(fs.readFileSync("tilemill/global_variables_only_labels.mss").toString());
+      mapconfig_light_only_labels.layers.push(new_layer);
+    } else if (!l.toggle[2]) {
+      new_layer.options.cartocss = replaceImages(fs.readFileSync(l.options.cartocss_file).toString());
+      mapconfig_light_only_labels.layers.push(new_layer);
+    }
+  });
+
   return {
-    'mapconfig_light':mapconfig_light,
-    'mapconfig_dark':mapconfig_dark,
-    'mapconfig_light_nolabels':mapconfig_light_nolabels,
-    'mapconfig_dark_nolabels':mapconfig_dark_nolabels
+    'mapconfig_light': mapconfig_light,
+    'mapconfig_dark': mapconfig_dark,
+    'mapconfig_light_nolabels': mapconfig_light_nolabels,
+    'mapconfig_dark_nolabels': mapconfig_dark_nolabels,
+    'mapconfig_light_only_labels': mapconfig_light_only_labels
   };
 }
 


### PR DESCRIPTION
this branch adds the possibility of generating a map with only the labels layers.

I've added a special variables file since the colors should change a little bit (IMHO)

cc @saleiva 

## how to generate in production

clone this repo:

```
git clone git@github.com:CartoDB/CartoDB-basemaps.git
```

generate the named map

```
node make_named_map.js mapconfig_light_only_labels > d.json
```

write it to the server

```
curl -H 'content-type: application/json' -d @d.json https://basemaps.cartodb.com/api/v1/map/named\?api_key\=XXXXXXX
```

use in cartodb with cartodb.js: https://gist.github.com/javisantana/fc692eb231336b788c8a

```
 cartodb.createLayer(map, {
            type: 'namedmap',
            user_name: 'basemaps',
            options: {
              named_map: {
                name: 'basemaps@mapconfig_light_only_labels'
              }
            }
          }).addTo(map)
```