### PR TITLE
Another style of rainbow for multipolygons

### DIFF
--- a/tilemill/buildings.mss
+++ b/tilemill/buildings.mss
@@ -15,7 +15,6 @@
   }
   [zoom >= 18] {
     [osm_id = 220254203], // Madrid
-    [osm_id = 279768154], // Brooklyn
     [osm_id = 260351411]  // Stamen
     {
       ::red {
@@ -51,6 +50,45 @@
         line-width:4;
         line-color: @landmass_fill;
         line-offset: 5;
+      }
+    }
+    // For multipolygons, we have to put the rainbow on the outside of the building
+    [osm_id = -3720805] // Brooklyn
+    {
+      polygon-clip: false;
+      ::red {
+        line-width:2;
+        line-color: red;
+        line-offset: 6;
+      }
+      ::orange {
+        line-width:2;
+        line-color: orange;
+        line-offset: 5;
+      }
+      ::yellow {
+        line-width:2;
+        line-color: yellow;
+        line-offset: 4;
+      }
+      ::green {
+        line-width:2;
+        line-color: green;
+        line-offset: 3;
+      }
+      ::blue {
+        line-width:2;
+        line-color: blue;
+        line-offset: 2;
+      }
+      ::purple {
+        line-width:2;
+        line-color: purple;
+        line-offset: 1;
+      }
+      ::refill {
+        // paint over any artifacts
+        polygon-fill: @buildings;
       }
     }
   }


### PR DESCRIPTION
The CartoDB office in Brooklyn is a multipolygon, so we need to specify a different ID for it (`[osm_id = -3720805], // Brooklyn`) but we also need to change the rainbow style because it breaks otherwise. Here's now the new style looks: 

![screen shot 2014-12-03 at 10 37 12 am](https://cloud.githubusercontent.com/assets/1212178/5278446/d729757c-7ad9-11e4-829a-011f2bdf8892.png)
