### PR TITLE
Hacky fix to avoid clipped neighborhood label

### DIFF
--- a/tilemill/country_city_labels.mss
+++ b/tilemill/country_city_labels.mss
@@ -87,6 +87,10 @@
     text-halo-fill: @labels_highzoom_halo_fill;
     text-fill: @labels_highzoom_text_fill;
 
+    [zoom=13][name='Barrio de la Latina'] {
+      text-name: ''; // Hack: avoid clipped label in this specific case
+    }
+
     text-min-distance: 10;
 
     // class 1 (bigger)

--- a/tilemill/global_variables.mss
+++ b/tilemill/global_variables.mss
@@ -103,8 +103,8 @@ Map {
 @osm_roads_labels_halo: white;
 
 // assets
-@city_shield_file: url("https://dl.dropboxusercontent.com/u/2682489/city_shield_light.svg");
-@city_shield_file_lowzoom: url("https://dl.dropboxusercontent.com/u/2682489/city_shield_light.svg");
+@city_shield_file: url("https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/city_shield_light.svg");
+@city_shield_file_lowzoom: url("https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/city_shield_light.svg");
 @capital_shield_file: url("https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/capital_shield_light.png");
 @capital_shield_file_lowzoom: url("https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/capital_shield_light.png");
 

--- a/tilemill/greenareas.mss
+++ b/tilemill/greenareas.mss
@@ -10,7 +10,7 @@
 
     polygon-pattern-alignment: global;
     polygon-pattern-opacity: @park_texture_opacity;
-    polygon-pattern-file: url(https://dl.dropboxusercontent.com/u/2682489/park-halftone-1.png);
+    polygon-pattern-file: url(https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/park-halftone-1.png);
   }
 
   [zoom>=11] {
@@ -24,7 +24,7 @@
 
     polygon-pattern-alignment: global;
     polygon-pattern-opacity: @park_texture_opacity;
-    polygon-pattern-file: url(https://dl.dropboxusercontent.com/u/2682489/park-halftone-1.png);
+    polygon-pattern-file: url(https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/park-halftone-1.png);
   }
 
   [zoom>=15]{
@@ -33,7 +33,7 @@
 
     polygon-pattern-alignment: global;
     polygon-pattern-opacity: @park_texture_opacity;
-    polygon-pattern-file: url(https://dl.dropboxusercontent.com/u/2682489/park-halftone-1.png);
+    polygon-pattern-file: url(https://dl.dropboxusercontent.com/u/2624290/stamen_cartodb_icons/park-halftone-1.png);
   }
   
 }


### PR DESCRIPTION
I'd prefer not to do it this way. But given that I can't find any clipped labels anywhere else on the map, and that this one bug is in such a prominent location (the center of Madrid), I think it's worth doing this as a quick fix.

If we find more clipped labels in the future, we should revisit #1 and find a better solution.